### PR TITLE
Updated project to netcoreapp2.2 and language version latest.

### DIFF
--- a/CatFactory.TypeScript.Tests/CatFactory.TypeScript.Tests.csproj
+++ b/CatFactory.TypeScript.Tests/CatFactory.TypeScript.Tests.csproj
@@ -1,23 +1,24 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <PropertyGroup>
+        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <LangVersion>latest</LangVersion>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
 
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.App" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0" />
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageReference>
+        <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\CatFactory.TypeScript\CatFactory.TypeScript.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\CatFactory.TypeScript\CatFactory.TypeScript.csproj" />
+    </ItemGroup>
 
 </Project>

--- a/CatFactory.TypeScript.Tests/Helpers/TextFileHelper.cs
+++ b/CatFactory.TypeScript.Tests/Helpers/TextFileHelper.cs
@@ -1,0 +1,25 @@
+﻿using System.IO;
+using System.Text;
+
+namespace CatFactory.Tests.Helpers
+{
+    public static class TextFileHelper
+    {
+        public static void WriteFile(string path, string data, FileMode mode, FileAccess access, Encoding encoding, bool addLine)
+        {
+            using (var file = new FileStream(path, mode, access))
+            {
+                using (var stream = new StreamWriter(file, encoding))
+                {
+                    if (addLine)
+                        stream.WriteLine(data);
+                    else
+                        stream.Write(data);
+                }
+            }
+        }
+
+        public static void CreateFile(string path, string data)
+            => WriteFile(path, data, FileMode.Create, FileAccess.Write, Encoding.Unicode, false);
+    }
+}

--- a/CatFactory.TypeScript.Tests/Helpers/XmlSerializer.cs
+++ b/CatFactory.TypeScript.Tests/Helpers/XmlSerializer.cs
@@ -1,0 +1,34 @@
+﻿using System.IO;
+using System.Xml;
+using System.Xml.Serialization;
+
+namespace CatFactory.Tests.Helpers
+{
+    public static class XmlSerializerHelper
+    {
+        public static string Serialize<T>(T obj)
+        {
+            var serializer = new XmlSerializer(obj.GetType());
+
+            using (var writer = new StringWriter())
+            {
+                serializer.Serialize(writer, obj);
+
+                return writer.ToString();
+            }
+        }
+
+        public static T DeserializeFrom<T>(string path)
+        {
+            var serializer = new XmlSerializer(typeof(T));
+
+            using (var stream = new FileStream(path, FileMode.Open))
+            {
+                using (var reader = XmlReader.Create(stream))
+                {
+                    return (T)serializer.Deserialize(reader);
+                }
+            }
+        }
+    }
+}

--- a/CatFactory.TypeScript.Tests/Helpers/XmlSerializerHelper.cs
+++ b/CatFactory.TypeScript.Tests/Helpers/XmlSerializerHelper.cs
@@ -2,7 +2,7 @@
 using System.Xml;
 using System.Xml.Serialization;
 
-namespace CatFactory.Tests.Helpers
+namespace CatFactory.TypeScript.Tests.Helpers
 {
     public static class XmlSerializerHelper
     {

--- a/CatFactory.TypeScript.Tests/ScaffoldingPaths.cs
+++ b/CatFactory.TypeScript.Tests/ScaffoldingPaths.cs
@@ -1,5 +1,9 @@
 ﻿namespace CatFactory.TypeScript.Tests
 {
+    using System.Linq;
+    using System.Xml.XPath;
+    using Microsoft.EntityFrameworkCore.Internal;
+
     public static class ScaffoldingPaths
     {
         public static string TscPath { get; }
@@ -8,9 +12,27 @@
 
         static ScaffoldingPaths()
         {
-            TscPath = @"C:\Program Files (x86)\Microsoft SDKs\TypeScript\3.0\tsc.exe";
-            TsFilesPath = @"C:\Temp\CatFactory.TypeScript";
-            OutPath = @"c:\Temp\CatFactory.TypeScript\js";
+            ScaffoldingPaths.TscPath = ScaffoldingPaths.WhereTsc();
+            ScaffoldingPaths.TsFilesPath = @"C:\Temp\CatFactory.TypeScript";
+            ScaffoldingPaths.OutPath = @"c:\Temp\CatFactory.TypeScript\js";
+        }
+
+        /// <summary>
+        /// Get the Last Known TypeScript Version
+        /// </summary>
+        /// <returns></returns>
+        static string WhereTsc()
+        {
+            var LastKnownTypeScriptVersion = "3.0";
+            var root = @"C:\Program Files (x86)\Microsoft SDKs\TypeScript";
+            var path = System.IO.Path.Combine(root, @"versions");
+            var di = new System.IO.DirectoryInfo(path);
+            if (di.Exists)
+            {
+                LastKnownTypeScriptVersion = System.Xml.Linq.XDocument.Load
+                    (di.EnumerateFileSystemInfos("*.props").Last().FullName).Root?.Value;
+            }
+            return System.IO.Path.Combine(root, LastKnownTypeScriptVersion, "tsc.exe");
         }
     }
 }

--- a/CatFactory.TypeScript/CatFactory.TypeScript.csproj
+++ b/CatFactory.TypeScript/CatFactory.TypeScript.csproj
@@ -1,26 +1,31 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-    <Version>1.0.0-beta-sun-build27</Version>
-    <Authors>H. Herzl</Authors>
-    <Description>CatFactory package for TypeScript scaffolding</Description>
-    <RepositoryUrl>https://github.com/hherzl/CatFactory.TypeScript</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PackageTags>TypeScript Scaffolding</PackageTags>
-    <PackageReleaseNotes>1.0.0-beta-sun-build27 Version:
+    <PropertyGroup>
+        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <LangVersion>latest</LangVersion>
+        <Version>1.0.0-beta-sun-build27</Version>
+        <Authors>H. Herzl</Authors>
+        <Description>CatFactory package for TypeScript scaffolding</Description>
+        <RepositoryUrl>https://github.com/hherzl/CatFactory.TypeScript</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <PackageTags>TypeScript Scaffolding</PackageTags>
+        <PackageReleaseNotes>1.0.0-beta-sun-build27 Version:
 
-* Core package update
+            * Core package update
 
-Quick start: https://www.codeproject.com/Tips/1166380/Scaffolding-TypeScript-with-CatFactory
-</PackageReleaseNotes>
-    <PackageProjectUrl>https://github.com/hherzl/CatFactory.TypeScript</PackageProjectUrl>
-    <Company>Herzl Corp.</Company>
-    <PackageLicenseUrl>https://github.com/hherzl/CatFactory.TypeScript/blob/master/LICENSE</PackageLicenseUrl>
-  </PropertyGroup>
+            Quick start: https://www.codeproject.com/Tips/1166380/Scaffolding-TypeScript-with-CatFactory
+        </PackageReleaseNotes>
+        <PackageProjectUrl>https://github.com/hherzl/CatFactory.TypeScript</PackageProjectUrl>
+        <Company>Herzl Corp.</Company>
+        <PackageLicenseUrl>https://github.com/hherzl/CatFactory.TypeScript/blob/master/LICENSE</PackageLicenseUrl>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="CatFactory" Version="1.0.0-beta-sun-build20" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\CatFactory\CatFactory\CatFactory.csproj" />
+    </ItemGroup>
 
 </Project>

--- a/CatFactory.TypeScript/CodeFactory/TypeScriptNamingConvention.cs
+++ b/CatFactory.TypeScript/CodeFactory/TypeScriptNamingConvention.cs
@@ -13,7 +13,7 @@ namespace CatFactory.TypeScript.CodeFactory
             => ValidName(string.Join(".", values.Select(item => item)));
 
         public string GetInterfaceName(string value)
-            => ValidName(NamingConvention.GetPascalCase(string.Format("I{0}", value)));
+            => ValidName($"I{NamingConvention.GetPascalCase(value)}");
 
         public string GetClassName(string value)
             => ValidName(NamingConvention.GetPascalCase(value));

--- a/CatFactory.TypeScript/CodeFactory/TypeScriptNamingConvention.cs
+++ b/CatFactory.TypeScript/CodeFactory/TypeScriptNamingConvention.cs
@@ -10,27 +10,27 @@ namespace CatFactory.TypeScript.CodeFactory
             => string.Join("", name.Split(' ').Select(item => NamingConvention.GetPascalCase(item)));
 
         public string GetNamespace(params string[] values)
-            => string.Join(".", values.Select(item => ValidName(item)));
+            => ValidName(string.Join(".", values.Select(item => item)));
 
         public string GetInterfaceName(string value)
-            => NamingConvention.GetPascalCase(string.Format("I{0}", ValidName(value)));
+            => ValidName(NamingConvention.GetPascalCase(string.Format("I{0}", value)));
 
         public string GetClassName(string value)
-            => NamingConvention.GetPascalCase(ValidName(value));
+            => ValidName(NamingConvention.GetPascalCase(value));
 
         public string GetConstantName(string value)
-            => NamingConvention.GetCamelCase(ValidName(value));
+            => ValidName(NamingConvention.GetCamelCase(value));
 
         public string GetFieldName(string value)
-            => NamingConvention.GetCamelCase(ValidName(value));
+            => ValidName(NamingConvention.GetCamelCase(value));
 
         public string GetPropertyName(string value)
-            => NamingConvention.GetCamelCase(ValidName(value));
+            => ValidName(NamingConvention.GetCamelCase(value));
 
         public string GetMethodName(string value)
-            => NamingConvention.GetCamelCase(ValidName(value));
+            => ValidName(NamingConvention.GetCamelCase(value));
 
         public string GetParameterName(string value)
-            => NamingConvention.GetCamelCase(ValidName(value));
+            => ValidName(NamingConvention.GetCamelCase(value));
     }
 }


### PR DESCRIPTION
Utilizes ProjectReference instead of PackageReference due to development.

Updated project to netcoreapp2.2 and language version latest.

Extended DotNetNamingConvention.ValidName() to use System.CodeDom class Microsoft.CSharp.CSharpCodeProvider().IsValidIdentifier() for native C# identifier validation. Tweaked invalidChars. ValidName() needs to be the outside method after case identifier modifications.

TSC Isn't always where you expect it to be
